### PR TITLE
quit after a timeout to allow devtools window to close

### DIFF
--- a/positron/modules/atom_browser_app.js
+++ b/positron/modules/atom_browser_app.js
@@ -11,7 +11,10 @@ Cu.import('resource://gre/modules/Services.jsm');
 exports.app = {
   quit() {
     // XXX Emit the before-quit and will-quit events.
-    Services.startup.quit(Services.startup.eAttemptQuit);
+	let timer = Cc["@mozilla.org/timer;1"].createInstance(Ci.nsITimer);
+	timer.initWithCallback({ notify: function() {
+	    Services.startup.quit(Services.startup.eAttemptQuit);
+	} }, 0, Ci.nsITimer.TYPE_ONE_SHOT);
   },
 };
 

--- a/positron/modules/atom_browser_web_contents.js
+++ b/positron/modules/atom_browser_web_contents.js
@@ -60,22 +60,15 @@ let WebContents_prototype = {
     let onLoad = () => {
       toolsWindow.removeEventListener("load", onLoad);
       toolsWindow.addEventListener("unload", onUnload);
-      window.addEventListener("unload", onBrowserUnload);
       this.emit("devtools-opened");
     }
     let onUnload = () => {
       toolsWindow.removeEventListener("unload", onUnload);
       toolsWindow.removeEventListener("message", onMessage);
-      window.removeEventListener("unload", onBrowserUnload);
       this.emit("devtools-closed");
     }
 
     // Close the DevTools window if the browser window closes
-    let onBrowserUnload = () => {
-      // XXX: If this unload handler is not present, the call to close the tools
-      // window in `onBrowserClosed` seems to not complete fast enough, blocking
-      // the quit process on Windows and Linux.
-    };
     let onBrowserClosed = () => {
       toolsWindow.close();
     };


### PR DESCRIPTION
@jryans This fixes the problem for me on Windows. I haven't yet tested to see if it makes the onBrowserUnload unnecessary yet.
